### PR TITLE
Missing float value type conversion

### DIFF
--- a/cmd/e3dc_exporter/exporter.go
+++ b/cmd/e3dc_exporter/exporter.go
@@ -51,8 +51,11 @@ func getValueFromMessage(message rscp.Message) float64 {
 		return float64(message.Value.(int32))
 	case rscp.Uint32:
 		return float64(message.Value.(uint32))
+	case rscp.Float32:
+		return float64(message.Value.(float32))
+	default:
+		logger.Warn("Got no value from message or could not decode value")
 	}
-	logger.Warn("Got no value from message")
 	return 0
 }
 


### PR DESCRIPTION
When E3DC returns a float32 value it didn't convert correctly to float64 for prometheus. Fixed that issue
